### PR TITLE
Remove unused commentable_id and _type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,5 +147,5 @@ license. Please see the [license file](license.md) for more information.
 [link-packagist]: https://packagist.org/packages/carropublic/discussion
 [link-downloads]: https://packagist.org/packages/carropublic/discussion
 [link-author]: https://github.com/carropublic
-[link-contributors]: ../../contributors]
+[link-contributors]: ../../contributors
 [link-laravel-comment-package]: https://github.com/beyondcode/laravel-comments

--- a/src/Traits/HasDiscussion.php
+++ b/src/Traits/HasDiscussion.php
@@ -26,8 +26,6 @@ trait HasDiscussion
             'discussion' => $discussion,
             'is_approved' => ($user instanceof DirectDiscussable) ? ! $user->discussionNeedApproval($this) : true,
             'user_id' => is_null($user) ? null : $user->getKey(),
-            'commentable_id' => $this->getKey(),
-            'commentable_type' => get_class(),
         ]);
 
         return $this->discussions()->save($discussionTopic);


### PR DESCRIPTION
Hello!

I found a bug related to the old naming (`commentable` instead of `discussable`).

In the `HasDiscussion` trait, when creating a new discussion, attributes `commentable_id` and `commentable_type` were still added to the object, which are no longer present in the migration.

Everything seemed to work, as the error only occurred with mass assignment without a guard.